### PR TITLE
remove jinja2 templating from when statements

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -38,7 +38,7 @@
     dest: /etc/chrony.conf
     state: absent
     regexp: '^server .*ntp.org iburst'
-  when: '{{ custom_ntp_servers is defined }}'
+  when: custom_ntp_servers is defined
   notify: restart chronyd
 
 - name: add custom servers to NTP config
@@ -47,7 +47,7 @@
     state: present
     line: 'server {{ item }} iburst'
   with_items: '{{ custom_ntp_servers|default([]) }}'
-  when: '{{ custom_ntp_servers is defined }}'
+  when: custom_ntp_servers is defined
   notify: restart chronyd
 
 - name: enabled chronyd

--- a/roles/cluster_master/tasks/main.yml
+++ b/roles/cluster_master/tasks/main.yml
@@ -4,7 +4,7 @@
     state: present
     dest: /etc/hosts
     line: "{{ hostvars[item]['ansible_ssh_host'] }} {{ item }}.novalocal {{ item }}"
-  when: "{{ hostvars[item]['ansible_ssh_host'] is defined }}"
+  when: hostvars[item]['ansible_ssh_host'] is defined
   with_items: "{{ groups['all'] }}"
   notify: restart_dnsmasq
 

--- a/tasks/vm_group_volume_attach.yml
+++ b/tasks/vm_group_volume_attach.yml
@@ -5,7 +5,7 @@
   with_sequence: count={{ vm_group.num_vms|default(1) }}
   async: 300
   register: async_volume_attach
-  when: "{{ volume_spec.size }}|default(0) > 0"
+  when: volume_spec.size|default(0) > 0
 
 - name: check volume attach status
   async_status: jid={{ item.ansible_job_id }}
@@ -14,4 +14,4 @@
   delay: 2
   retries: 150
   with_items: "{{ async_volume_attach.results }}"
-  when: "{{ volume_spec.size }}|default(0) > 0"
+  when: volume_spec.size|default(0) > 0

--- a/tasks/vm_group_volume_deprovision.yml
+++ b/tasks/vm_group_volume_deprovision.yml
@@ -8,7 +8,7 @@
   with_sequence: count={{ vm_group.num_vms|default(1) }}
   async: 300
   register: async_volume_remove
-  when: "{{ volume_spec.size }}|default(0) > 0"
+  when: volume_spec.size|default(0) > 0
 
 - name: check volume remove status
   async_status: jid={{ item.ansible_job_id }}
@@ -17,4 +17,4 @@
   retries: 30
   delay: 15
   with_items: "{{ async_volume_remove.results }}"
-  when: "{{ volume_spec.size }}|default(0) > 0"
+  when: volume_spec.size|default(0) > 0

--- a/tasks/vm_group_volume_provision.yml
+++ b/tasks/vm_group_volume_provision.yml
@@ -8,7 +8,7 @@
   with_sequence: count={{ vm_group.num_vms|default(1) }}
   async: 300
   register: async_volume_create
-  when: "{{ volume_spec.size }}|default(0) > 0"
+  when: volume_spec.size|default(0) > 0
 
 - name: check volume create status
   async_status: jid={{ item.ansible_job_id }}
@@ -17,4 +17,4 @@
   delay: 2
   retries: 150
   with_items: "{{ async_volume_create.results }}"
-  when: "{{ volume_spec.size }}|default(0) > 0"
+  when: volume_spec.size|default(0) > 0


### PR DESCRIPTION
Ansible 2.3 spits warnings about jinja2 template variable syntax in
when statements. See

http://docs.ansible.com/ansible/playbooks_conditionals.html#the-when-statement
http://stackoverflow.com/questions/42673045/ansible-when-statements-should-not-include-jinja2-templating-delimiters