### PR TITLE
support setting explicit metrics version in inventory

### DIFF
--- a/playbooks/openshift/example_cluster_vars.yaml
+++ b/playbooks/openshift/example_cluster_vars.yaml
@@ -91,6 +91,9 @@ oso_install_containerized: false
 # deploy metrics during installation
 oso_deploy_metrics: false
 
+# specify a custom version for metrics
+#oso_metrics_tag: latest
+
 # deploy logging during installation
 oso_deploy_logging: false
 

--- a/playbooks/openshift/templates/inventory.multimaster.j2
+++ b/playbooks/openshift/templates/inventory.multimaster.j2
@@ -69,6 +69,7 @@ openshift_hosted_router_certificate={'certfile': '{{ certificate_crt }}', 'keyfi
 # deploy metrics service
 openshift_hosted_metrics_deploy={{ oso_deploy_metrics|default(false)|bool }}
 openshift_hosted_metrics_resolution=20s
+openshift_hosted_metrics_deployer_version={{ oso_metrics_tag|default(oso_image_tag|default('v'+oso_release|default('latest'))) }}
 
 # deploy aggregated logging service
 openshift_hosted_logging_deploy={{ oso_deploy_logging|default(false)|bool }}

--- a/playbooks/openshift/templates/inventory.single_master.j2
+++ b/playbooks/openshift/templates/inventory.single_master.j2
@@ -64,6 +64,7 @@ openshift_hosted_router_certificate={'certfile': '{{ certificate_crt }}', 'keyfi
 # deploy metrics service
 openshift_hosted_metrics_deploy={{ oso_deploy_metrics|default(false)|bool }}
 openshift_hosted_metrics_resolution=20s
+openshift_hosted_metrics_deployer_version={{ oso_metrics_tag|default(oso_image_tag|default('v'+oso_release|default('latest'))) }}
 
 # deploy aggregated logging service
 openshift_hosted_logging_deploy={{ oso_deploy_logging|default(false)|bool }}


### PR DESCRIPTION
Take metrics image version from specified release, image tag or
explicitly set oso_metrics_tag. The installer defaults to 'latest',
which can lead to problems later when incompatible changes are
introduced.