### PR TITLE
set nodeSelector for metrics pods

### DIFF
--- a/playbooks/openshift/templates/inventory.multimaster.j2
+++ b/playbooks/openshift/templates/inventory.multimaster.j2
@@ -70,6 +70,9 @@ openshift_hosted_router_certificate={'certfile': '{{ certificate_crt }}', 'keyfi
 openshift_hosted_metrics_deploy={{ oso_deploy_metrics|default(false)|bool }}
 openshift_hosted_metrics_resolution=20s
 openshift_hosted_metrics_deployer_version={{ oso_metrics_tag|default(oso_image_tag|default('v'+oso_release|default('latest'))) }}
+openshift_metrics_heapster_nodeselector={'type': 'master'}
+openshift_metrics_hawkular_nodeselector={'type': 'master'}
+openshift_metrics_cassandra_nodeselector={'type': 'master'}
 
 # deploy aggregated logging service
 openshift_hosted_logging_deploy={{ oso_deploy_logging|default(false)|bool }}

--- a/playbooks/openshift/templates/inventory.single_master.j2
+++ b/playbooks/openshift/templates/inventory.single_master.j2
@@ -65,10 +65,13 @@ openshift_hosted_router_certificate={'certfile': '{{ certificate_crt }}', 'keyfi
 openshift_hosted_metrics_deploy={{ oso_deploy_metrics|default(false)|bool }}
 openshift_hosted_metrics_resolution=20s
 openshift_hosted_metrics_deployer_version={{ oso_metrics_tag|default(oso_image_tag|default('v'+oso_release|default('latest'))) }}
-openshift_logging_image_version={{ oso_logging_tag|default(oso_image_tag|default('v'+oso_release|default('latest'))) }}
+openshift_metrics_heapster_nodeselector={'type': 'master'}
+openshift_metrics_hawkular_nodeselector={'type': 'master'}
+openshift_metrics_cassandra_nodeselector={'type': 'master'}
 
 # deploy aggregated logging service
 openshift_hosted_logging_deploy={{ oso_deploy_logging|default(false)|bool }}
+openshift_logging_image_version={{ oso_logging_tag|default(oso_image_tag|default('v'+oso_release|default('latest'))) }}
 
 # reduce master memory usage
 osm_api_server_args={'deserialization-cache-size': ['1000']}


### PR DESCRIPTION
Heapster needs to be run on infra-nodes to have access to node API.
The new openshift_metrics -role in installer supports setting
nodeSelectors, so we set them in the inventory avoiding a manual step
after installation.