### PR TITLE
remove extra openshift_hostname variable in inventory for nfs

### DIFF
--- a/playbooks/openshift/templates/inventory.multimaster.j2
+++ b/playbooks/openshift/templates/inventory.multimaster.j2
@@ -190,7 +190,7 @@ pv_vg_pvol=vg_pvol
 
 [nfsservers]
 {% if nfs is defined and nfs.num_vms|default(0) > 0 %}
-{{ groups['nfs'][0] }} openshift_hostname={{ vm }} ansible_ssh_host={{ hostvars[groups['nfs'][0]]['ansible_ssh_host'] }}
+{{ groups['nfs'][0] }} ansible_ssh_host={{ hostvars[groups['nfs'][0]]['ansible_ssh_host'] }}
 {% endif %}
 
 [etcd:vars]


### PR DESCRIPTION
Remove a an extraneous attribute and a invalid variable reference for nfs server in multimaster inventory template. This looks like it was introduced when openshift_hostname -attributes in inventory were added to provide human readable names for nodes. NFS server does not need it, because it does not act as an OpenShift node.