### PR TITLE
update OpenShift installation instructions

### DIFF
--- a/playbooks/openshift/README.md
+++ b/playbooks/openshift/README.md
@@ -140,6 +140,19 @@ Add a user
 - start testing and learning
 - get a proper certificate for master
 
+## Deprovisioning
+
+To deprovision all the resources, run
+
+    $ ansible-playbook -v -e @cluster_vars.yaml \
+    -e remove_nodes=1 -e remove_node_volumes=1 \
+    -e remove_masters=1 -e remove_master_volumes=1 \
+    -e remove_etcd=1 \
+    -e remove_lbs=1 -e remove_lb_volumes=1 \
+    -e remove_nfs=1 -e remove_nfs_volumes=1 \
+    -e remove_security_groups=1 \
+    ~/git/pouta-ansible-cluster/playbooks/openshift/deprovision.yml
+
 ## Security groups
 
 - common

--- a/playbooks/openshift/README.md
+++ b/playbooks/openshift/README.md
@@ -44,13 +44,15 @@ This is a log of an example installation of a proof of concept cluster with
 Shell environment with
 - OpenStack credentials for cPouta 
 - python virtualenv with ansible==2.3, shade, dnspython and pyopenssl
-- venv should have latest setuptools and pip (pip install --upgrade setuptools pip)
+- venv should have latest setuptools and pip (pip install --upgrade pip setuptools)
 - metrics needs java keytool on the bastion host: sudo yum install java-1.8.0-openjdk-headless
 - if you have SELinux enabled, either disable that or make sure the virtualenv has libselinux-python  
 - ssh access to the internal network of your project
     - either run this on your bastion host
     - or set up ssh forwarding through your bastion host in your ~/.ssh/config
     - please test ssh manually after provisioning 
+
+For packages on CentOS-7, see: [Creating a bastion host](../../CREATE_BASTION_HOST.md)
 
 For automatic, self-provisioned app routes to work, you will need a wildcard DNS CNAME for your master's public IP.
  
@@ -64,7 +66,7 @@ Clone the necessary playbooks from GitHub (here we assume they go under ~/git)
     $ git clone https://github.com/CSCfi/pouta-ansible-cluster
     $ git clone https://github.com/tourunen/openshift-ansible.git openshift-ansible-tourunen
     $ cd openshift-ansible-tourunen
-    $ git checkout nfs_fixes
+    $ git checkout release-1.5-csc
 
 ### Create a cluster config
 
@@ -76,15 +78,22 @@ Decide a name for your cluster, create a new directory and copy the example conf
     $ cp ~/git/pouta-ansible-cluster/playbooks/openshift/example_cluster_vars.yaml cluster_vars.yaml
 
 Change at least the following config entries:
+
     cluster_name: "YOUR_CLUSTER_NAME" 
     ssh_key: "bastion-key"
-
+    openshift_public_hostname: "your.master.hostname.here"
+    openshift_public_ip: "your.master.ip.here"
+    
 If you are deploying the cluster to a non-default network, remember to add and configure an interface to bastion host in
 that network. The network also needs to be attached to a router.
 
 ### Run provisioning
 
-First provision the VMs and associated resources
+Source your openstack credentials first
+
+    $ source ~/openrc.bash
+
+Provision the VMs and associated resources
 
     $ workon ansible-2.3
     $ ansible-playbook -v -e @cluster_vars.yaml ~/git/pouta-ansible-cluster/playbooks/openshift/provision.yml 
@@ -95,32 +104,35 @@ Then prepare the VMs for installation
      
 Finally run the installer (this will take a while).
     
-    $ ansible-playbook -v -b -i openshift-inventory ~/git/openshift-ansible/playbooks/byo/config.yml
+    $ ansible-playbook -v -b -i openshift-inventory ~/git/openshift-ansible-tourunen/playbooks/byo/config.yml
 
 Also, create the persistent volumes at this point. Edit the playbook to suit your needs, then run it. Note that if you
 want to deploy a registry with persistent storage, you will need at least one pvol to hold the data for the registry.
 
     $ vi ~/git/openshift-ansible-tourunen/setup_lvm_nfs.yml
-    $ ansible-playbook -v -i openshift-inventory ~/git/openshift-ansible-tourunen/setup_lvm_nfs.yml
+    $ ansible-playbook -v -i openshift-inventory -e @cluster_vars.yaml ~/git/pouta-ansible-cluster/playbooks/openshift/post_install.yml
 
 ### Configure the cluster
 
-Login to the master, switch to root
+Login to the master
 
-    $ ssh cloud-user@your.masters.internal.ip
-    $ sudo -i
+    $ ssh cloud-user@your-master-1
     
-Add the persistent volumes that were created earlier to OpenShift
+Add the persistent volumes that were created during post install to OpenShift
 
-    $ for vol in persistent-volume.pvol*; do oc create -f $vol; done
+    $ for vol in nfs_pv/persistent-volume.pvol*; do oc create -f $vol; done
 
 Re-deploy registry with persistent storage. Note that you need a pvol that is at least 200GB for this.
 
     $ oc volume dc/docker-registry --add --mount-path=/registry --overwrite --name=registry-storage -t pvc --claim-size=200Gi 
 
+Add the default project request object (before this step no projects can be created)
+
+    $ oc create -f project-request.yaml
+    
 Add a user
     
-    $ htpasswd -c /etc/origin/master/htpasswd alice
+    $ sudo htpasswd -c /etc/origin/master/htpasswd alice
 
 ## Further actions
 

--- a/playbooks/openshift/README.md
+++ b/playbooks/openshift/README.md
@@ -83,6 +83,7 @@ Change at least the following config entries:
     ssh_key: "bastion-key"
     openshift_public_hostname: "your.master.hostname.here"
     openshift_public_ip: "your.master.ip.here"
+    project_external_ips: ["your.master.ip.here"]
     
 If you are deploying the cluster to a non-default network, remember to add and configure an interface to bastion host in
 that network. The network also needs to be attached to a router.

--- a/playbooks/openshift/example_cluster_vars.yaml
+++ b/playbooks/openshift/example_cluster_vars.yaml
@@ -85,7 +85,7 @@ build:
 oso_install_containerized: false
 # if you use containerized install, this has to be set.
 # See https://hub.docker.com/r/openshift/origin/tags/
-#oso_image_tag: v1.3.0-alpha.3
+#oso_image_tag: v1.4.1
 #oso_release: latest
 
 # deploy metrics during installation


### PR DESCRIPTION
- updated image tag to 1.4.1 in example_cluster_vars.yaml
- added a reference to bastion host instructions
- updated the branch reference for openshift-ansible-tourunen
- updated instructions for creating cluster_vars.yaml
- fixed references to local checkout of OpenShift installer
- changed setup_lvm_nfs playbook to generic post_install playbook
- dropped using root shell for actions after installation
- added deprovisioning example
- added project_external_ips to the list of variables to configure