### PR TITLE
Set ansible_{ssh_user,become} for NFS servers

### DIFF
--- a/playbooks/openshift/templates/inventory.multimaster.j2
+++ b/playbooks/openshift/templates/inventory.multimaster.j2
@@ -180,6 +180,8 @@ openshift_node_labels={{ labels }}
 [nfsservers:vars]
 vm_group_name=nfs
 pv_vg_pvol=vg_pvol
+ansible_ssh_user=cloud-user
+ansible_become=true
 
 {% if nfs is defined %}
 {% for group_var_key, group_var_value in (lb.group_vars|default({})).iteritems() %}

--- a/playbooks/openshift/templates/inventory.single_master.j2
+++ b/playbooks/openshift/templates/inventory.single_master.j2
@@ -154,6 +154,8 @@ vm_group_name={{ group_name }}
 [nfsservers:vars]
 vm_group_name=nfs
 pv_vg_pvol=vg_pvol
+ansible_ssh_user=cloud-user
+ansible_become=true
 
 {% if nfs is defined %}
 {% for group_var_key, group_var_value in (nfs.group_vars|default({})).iteritems() %}


### PR DESCRIPTION
Previously the ansible_ssh_user and ansible_become variables were not
being set for NFS servers. This caused Ansible to be unable to connect
to these servers as the proper username was not being used. For other
servers the username is set in the OSEv3 group, but the NFS servers do
not belong to this group.

Set ansible_ssh_user to cloud-user and ansible_become to true in the NFS
server inventory group.