### PR TITLE
Make sure dir exists for autogenerated inventory

### DIFF
--- a/playbooks/openshift/provision.yml
+++ b/playbooks/openshift/provision.yml
@@ -252,6 +252,11 @@
   hosts: localhost
   connection: local
   tasks:
+    - name: make sure the directory for inventory files exists
+      file:
+        state: directory
+        path: "{{ ansible_env.HOME }}/{{ cluster_name }}"
+
     - name: create inventory on disk (multimaster)
       template:
         src: templates/inventory.multimaster.j2


### PR DESCRIPTION
The "Generate inventory, tmuxinator config and ssh config" task assumes
that the directory {{ ansible_env.HOME }}/{{ cluster_name }} already
exists. This directory should be created before running the task to
make sure inventory creation does not fail. Create this inventory.