### PR TITLE
service module running state to started

### DIFF
--- a/roles/ambari_server/tasks/main.yml
+++ b/roles/ambari_server/tasks/main.yml
@@ -33,7 +33,7 @@
     creates: /etc/ambari-server/conf/password.dat
 
 - name: start ambari service
-  service: name=ambari-server state=running enabled=yes
+  service: name=ambari-server state=started enabled=yes
 
 - name: allow access to ambari
   lineinfile:

--- a/roles/docker_host/tasks/main.yml
+++ b/roles/docker_host/tasks/main.yml
@@ -11,4 +11,4 @@
   yum: name=docker state=present
 
 - name: enable docker service
-  service: name=docker state=running enabled=yes
+  service: name=docker state=started enabled=yes


### PR DESCRIPTION
service module state 'running' is now deprecated and should be
replaced with 'started'

http://docs.ansible.com/ansible/service_module.html#options