### PR TITLE
Feature/quota and admission

### DIFF
--- a/playbooks/openshift/config.yml
+++ b/playbooks/openshift/config.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Run basic cluster configuration
+  include: configure.yml
+
+- name: Run OpenShift Origin installer
+  include: ../../../openshift-ansible/playbooks/byo/config.yml
+
+- name: Run configuration tasks against OpenShift
+  include: post_install.yml

--- a/playbooks/openshift/example_cluster_vars.yaml
+++ b/playbooks/openshift/example_cluster_vars.yaml
@@ -100,6 +100,10 @@ oso_deploy_logging: false
 # specify a custom version for metrics
 #oso_logging_tag: latest
 
+# instead of using playbooks/openshift/templates/project-request.yml
+# for default quotas for new projects, use a custom file
+#oso_default_project_request: "/path/to/custom/project-request.yml"
+
 openshift_public_hostname: "your.master.hostname.here"
 openshift_public_ip: "your.master.ip.here"
 openshift_builddefaults_nodeselectors: "{'type':'build'}"

--- a/playbooks/openshift/post_install.yml
+++ b/playbooks/openshift/post_install.yml
@@ -1,15 +1,43 @@
 - name: Run NFS volume creation
   include: ../../../openshift-ansible-tourunen/setup_lvm_nfs.yml
 
-- name: Copy files to master-1
+- name: Import objects through master-1
   hosts: masters[0]
   tasks:
-    - name: copy default project template to master-1
-      template:
-        src: templates/project-request.yaml
-        dest: /home/cloud-user/project-request.yaml
-
     - name: copy nfs_pv definitions to master-1
       copy:
         src: /tmp/nfs_pv
         dest: /home/cloud-user/
+
+    - name: create PVs
+      shell: for vol in nfs_pv/persistent-volume.pvol*; do oc create -f $vol; done
+      failed_when: false
+
+    - name: check if registry PV exists
+      shell: oc get pvc -n default registry
+      register: existing_registry_pv
+      changed_when: false
+      failed_when: false
+
+    - name: add a persistent volume to the registry
+      shell: oc volume dc/docker-registry --add --mount-path=/registry --overwrite --name=registry-storage -t pvc --claim-size=200Gi --claim-name=registry
+      when: existing_registry_pv.stdout_lines | length == 0
+
+    - name: copy default project template to master-1
+      template:
+        src: "{{ oso_default_project_request|default('templates/project-request.yaml') }}"
+        dest: /home/cloud-user/project-request.yaml
+
+    - name: check if project template exists
+      shell: oc get template -n default project-request-default
+      register: existing_template
+      changed_when: false
+      failed_when: false
+
+    - name: import project template
+      shell: oc create -f /home/cloud-user/project-request.yaml
+      when: existing_template.stdout_lines | length == 0
+
+    - name: update project template
+      shell: oc replace -f /home/cloud-user/project-request.yaml
+      when: existing_template.stdout_lines | length > 0

--- a/playbooks/openshift/templates/inventory.multimaster.j2
+++ b/playbooks/openshift/templates/inventory.multimaster.j2
@@ -90,6 +90,11 @@ openshift_buildoverrides_nodeselectors={{ openshift_buildoverrides_nodeselectors
 {% endif %}
 openshift_buildoverrides_force_pull=True
 
+{% if openshift_master_admission_plugin_config is defined %}
+# Admission plugin config
+openshift_master_admission_plugin_config={{ openshift_master_admission_plugin_config }}
+{% endif %}
+
 #
 # Host definitions
 #

--- a/playbooks/openshift/templates/inventory.single_master.j2
+++ b/playbooks/openshift/templates/inventory.single_master.j2
@@ -85,6 +85,11 @@ openshift_buildoverrides_nodeselectors={{ openshift_buildoverrides_nodeselectors
 {% endif %}
 openshift_buildoverrides_force_pull=True
 
+{% if openshift_master_admission_plugin_config is defined %}
+# Admission plugin config
+openshift_master_admission_plugin_config={{ openshift_master_admission_plugin_config }}
+{% endif %}
+
 #
 # Host definitions
 #


### PR DESCRIPTION
- support for admission plugin config. By supporting custom admission plugin config we can enable
for example limits for the number of self-serviced projects.
- support for custom project quota file
- automatic NFS volume creation
- making the automatically deployed registry use persistent storage
- added an aggregate playbook for all post provisioning tasks and simplified the instructions accordingly
