### PR TITLE
Remove clouds.yaml

### DIFF
--- a/playbooks/openshift/clouds.yaml
+++ b/playbooks/openshift/clouds.yaml
@@ -1,5 +1,0 @@
----
-ansible:
-  use_hostnames: True
-  expand_hostvars: True
-  fail_on_errors: True


### PR DESCRIPTION
The clouds.yaml config file that is used to configure the
openstack.py dynamic inventory script is not needed after all, as we've
modified the script defaults to be more sane. The only thing that was
being set by cloud.yaml was one boolean value, basically. Remove
clouds.yaml.