### PR TITLE
Always create dedicated net+router for OpenShift

### DIFF
--- a/playbooks/openshift/README.md
+++ b/playbooks/openshift/README.md
@@ -42,6 +42,10 @@ what to do or willing to learn. Do not expect that after completing the steps yo
 
 - used to tear the cluster resources down when using provision.yml
 
+### heat_deprovision.yml
+
+- used to tear the cluster resources down when using heat_provision.yml
+
 ### site.yml
 
 - aggregates all installation steps after provisioning into a single playbook
@@ -222,10 +226,13 @@ To deprovision all the resources, run
 
 ### Deprovisioning when using Heat
 
-Just delete the Heat stack. This deletes all resources in one go. Partial
-deletes are not currently supported, as the Heat stack update process does not
-nicely replace missing resources. This may be possible in newer OpenStack
-versions.
+    $ ansible-playbook heat_deprovision.yml \
+    -i <inventory directory/file> \
+    --ask-vault-pass
+
+Partial deletes are not currently supported, as the Heat stack update process
+does not nicely replace missing resources. This may be possible in newer
+OpenStack versions.
 
 ## Security groups
 

--- a/playbooks/openshift/files/openshift-heat-stack.yml
+++ b/playbooks/openshift/files/openshift-heat-stack.yml
@@ -25,10 +25,22 @@ parameters:
     description: >
       Rules for the security group that governs external access to the system.
     type: json
-  openshift_networks:
+  openshift_network_cidr:
     description: >
-      The network config for VMs in the OpenShift cluster.
-    type: json
+      What CIDR to use for the dedicated cluster network.
+    type: string
+    default: '192.168.0.0/16'
+  openshift_network_dns_servers:
+    description: >
+      What DNS servers to use in the dedicated cluster network.
+    type: comma_delimited_list
+    default: '193.166.4.24,193.166.4.25'
+  public_network_id:
+    description: >
+      The public network in OpenStack to which the dedicated cluster net router
+      should be connected to.
+    type: string
+    default: 'public'
   key_name:
     description: >
       The name of the SSH key to initially insert into VMs.
@@ -219,6 +231,46 @@ resources:
           remote_group_id: { get_resource: secgroup_infra }
 
   #-----------------------------------
+  # Dedicated cluster network
+  #-----------------------------------
+
+  openshift_network:
+    type: OS::Neutron::Net
+    properties:
+       name:
+         str_replace:
+            template: env_name-name_suffix
+            params:
+              env_name: { get_param: env_name }
+              name_suffix: "network"
+
+  openshift_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: openshift_network }
+      cidr: { get_param: openshift_network_cidr }
+      dns_nameservers: { get_param: openshift_network_dns_servers }
+
+  openshift_router:
+    type: OS::Neutron::Router
+    depends_on: "openshift_subnet"
+    properties:
+      name:
+        str_replace:
+            template: env_name-name_suffix
+            params:
+              env_name: { get_param: env_name }
+              name_suffix: "router"
+      external_gateway_info:
+        network: { get_param: public_network_id }
+
+  openshift_subnet_router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: openshift_router }
+      subnet: { get_resource: openshift_subnet }
+
+  #-----------------------------------
   # Bastion VM
   #-----------------------------------
 
@@ -229,6 +281,7 @@ resources:
 
   bastion:
     type: OS::Nova::Server
+    depends_on: "openshift_subnet"
     properties:
       name:
         str_replace:
@@ -237,7 +290,8 @@ resources:
             env_name: { get_param: env_name }
             name_suffix: "bastion"
       image: { get_param: bastion_vm_image }
-      networks: { get_param: openshift_networks }
+      networks:
+        - network: { get_resource: openshift_network }
       flavor: { get_param: bastion_vm_flavor }
       metadata:
         group: "bastion"
@@ -287,6 +341,7 @@ resources:
 
   etcd_vm_group:
     type: OS::Heat::ResourceGroup
+    depends_on: "openshift_subnet"
     properties:
       count: { get_param: etcd_vm_group_size }
       resource_def:
@@ -299,7 +354,8 @@ resources:
                 env_name: { get_param: env_name }
                 name_suffix: "etcd"
           image: { get_param: etcd_vm_image }
-          networks: { get_param: openshift_networks }
+          networks:
+            - network: { get_resource: openshift_network }
           flavor: { get_param: etcd_vm_flavor }
           metadata:
             group: "etcd"
@@ -312,6 +368,7 @@ resources:
 
   lb_vm_group:
     type: OS::Heat::ResourceGroup
+    depends_on: "openshift_subnet"
     properties:
       count: { get_param: lb_vm_group_size }
       resource_def:
@@ -324,7 +381,8 @@ resources:
                 env_name: { get_param: env_name }
                 name_suffix: "lb"
           image: { get_param: lb_vm_image }
-          networks: { get_param: openshift_networks }
+          networks:
+            - network: { get_resource: openshift_network }
           flavor: { get_param: lb_vm_flavor }
           metadata:
             groups: "lb,node_lbs"
@@ -341,6 +399,7 @@ resources:
 
   nfs_vm_group:
     type: OS::Heat::ResourceGroup
+    depends_on: "openshift_subnet"
     properties:
       count: { get_param: nfs_vm_group_size }
       resource_def:
@@ -353,7 +412,8 @@ resources:
                 env_name: { get_param: env_name }
                 name_suffix: "nfs"
           image: { get_param: nfs_vm_image }
-          networks: { get_param: openshift_networks }
+          networks:
+            - network: { get_resource: openshift_network }
           flavor: { get_param: nfs_vm_flavor }
           metadata:
             group: "nfsservers"
@@ -369,6 +429,7 @@ resources:
 
   master_vm_group:
     type: OS::Heat::ResourceGroup
+    depends_on: "openshift_subnet"
     properties:
       count: { get_param: master_vm_group_size }
       resource_def:
@@ -381,7 +442,8 @@ resources:
                 env_name: { get_param: env_name }
                 name_suffix: "master"
           image: { get_param: master_vm_image }
-          networks: { get_param: openshift_networks }
+          networks:
+            - network: { get_resource: openshift_network }
           flavor: { get_param: master_vm_flavor }
           metadata:
             groups: "masters,node_masters"
@@ -395,6 +457,7 @@ resources:
 
   node_ssd_vm_group:
     type: OS::Heat::ResourceGroup
+    depends_on: "openshift_subnet"
     properties:
       count: { get_param: node_ssd_vm_group_size }
       resource_def:
@@ -407,7 +470,8 @@ resources:
                 env_name: { get_param: env_name }
                 name_suffix: "ssd"
           image: { get_param: node_ssd_vm_image }
-          networks: { get_param: openshift_networks }
+          networks:
+            - network: { get_resource: openshift_network }
           flavor: { get_param: node_ssd_vm_flavor }
           metadata:
             group: "ssd"

--- a/playbooks/openshift/heat_deprovision.yml
+++ b/playbooks/openshift/heat_deprovision.yml
@@ -1,0 +1,25 @@
+---
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Disassociate floating IP from bastion
+      os_floating_ip:
+        server: "{{ cluster_name }}-bastion"
+        floating_ip_address: "{{ bastion_public_ip }}"
+        state: absent
+    - name: Disassociate floating IP from first LB node
+      os_floating_ip:
+        server: "{{ cluster_name }}-lb-0"
+        floating_ip_address: "{{ openshift_public_ip }}"
+        state: absent
+      when: lb_vm_group_size > 0
+    - name: Disassociate floating IP from first master node
+      os_floating_ip:
+        server: "{{ cluster_name }}-master-0"
+        floating_ip_address: "{{ openshift_public_ip }}"
+        state: absent
+      when: lb_vm_group_size == 0
+    - name: Delete stack {{ cluster_name }}
+      os_stack:
+        name: "{{ cluster_name }}"
+        state: absent

--- a/playbooks/openshift/heat_provision.yml
+++ b/playbooks/openshift/heat_provision.yml
@@ -12,7 +12,6 @@
           env_name: "{{ cluster_name }}"
           bastion_allow_cidrs: "{{ bastion_allow_cidrs }}"
           secgroup_ext_access_rules: "{{ secgroup_ext_access_rules }}"
-          openshift_networks: "{{ openshift_networks }}"
           key_name: "{{ key_name }}"
           bastion_vm_image: "{{ bastion_vm_image }}"
           bastion_vm_flavor: "{{ bastion_vm_flavor }}"


### PR DESCRIPTION
Modify the Heat template for the OpenShift cluster so that a dedicated
router and network is always created. Use the defaults when creating
these dedicated resources via os_stack.