### PR TITLE
Better reliability for OpenShift Heat provisioning

### DIFF
--- a/playbooks/openshift/files/openshift-heat-stack-minimal.yml
+++ b/playbooks/openshift/files/openshift-heat-stack-minimal.yml
@@ -29,18 +29,17 @@ parameters:
     description: >
       What CIDR to use for the dedicated cluster network.
     type: string
-    default: '192.168.0.0/16'
+    default: '192.168.10.0/24'
   openshift_network_dns_servers:
     description: >
       What DNS servers to use in the dedicated cluster network.
     type: comma_delimited_list
     default: '193.166.4.24,193.166.4.25'
-  public_network_id:
+  openshift_router:
     description: >
-      The public network in OpenStack to which the dedicated cluster net router
-      should be connected to.
+      The router to which the dedicated cluster network should be connected to
+      for external access.
     type: string
-    default: 'public'
   key_name:
     description: >
       The name of the SSH key to initially insert into VMs.
@@ -211,23 +210,10 @@ resources:
       cidr: { get_param: openshift_network_cidr }
       dns_nameservers: { get_param: openshift_network_dns_servers }
 
-  openshift_router:
-    type: OS::Neutron::Router
-    depends_on: "openshift_subnet"
-    properties:
-      name:
-        str_replace:
-            template: env_name-name_suffix
-            params:
-              env_name: { get_param: env_name }
-              name_suffix: "router"
-      external_gateway_info:
-        network: { get_param: public_network_id }
-
   openshift_subnet_router_interface:
     type: OS::Neutron::RouterInterface
     properties:
-      router: { get_resource: openshift_router }
+      router: { get_param: openshift_router }
       subnet: { get_resource: openshift_subnet }
 
   #-----------------------------------

--- a/playbooks/openshift/files/openshift-heat-stack.yml
+++ b/playbooks/openshift/files/openshift-heat-stack.yml
@@ -29,18 +29,17 @@ parameters:
     description: >
       What CIDR to use for the dedicated cluster network.
     type: string
-    default: '192.168.0.0/16'
+    default: '192.168.10.0/24'
   openshift_network_dns_servers:
     description: >
       What DNS servers to use in the dedicated cluster network.
     type: comma_delimited_list
     default: '193.166.4.24,193.166.4.25'
-  public_network_id:
+  openshift_router:
     description: >
-      The public network in OpenStack to which the dedicated cluster net router
-      should be connected to.
+      The router to which the dedicated cluster network should be connected to
+      for external access.
     type: string
-    default: 'public'
   key_name:
     description: >
       The name of the SSH key to initially insert into VMs.
@@ -251,23 +250,10 @@ resources:
       cidr: { get_param: openshift_network_cidr }
       dns_nameservers: { get_param: openshift_network_dns_servers }
 
-  openshift_router:
-    type: OS::Neutron::Router
-    depends_on: "openshift_subnet"
-    properties:
-      name:
-        str_replace:
-            template: env_name-name_suffix
-            params:
-              env_name: { get_param: env_name }
-              name_suffix: "router"
-      external_gateway_info:
-        network: { get_param: public_network_id }
-
   openshift_subnet_router_interface:
     type: OS::Neutron::RouterInterface
     properties:
-      router: { get_resource: openshift_router }
+      router: { get_param: openshift_router }
       subnet: { get_resource: openshift_subnet }
 
   #-----------------------------------

--- a/playbooks/openshift/heat_provision.yml
+++ b/playbooks/openshift/heat_provision.yml
@@ -14,6 +14,8 @@
             env_name: "{{ cluster_name }}"
             bastion_allow_cidrs: "{{ bastion_allow_cidrs }}"
             secgroup_ext_access_rules: "{{ secgroup_ext_access_rules }}"
+            openshift_network_cidr: "{{ openshift_network_cidr }}"
+            openshift_router: "{{ openshift_router }}"
             key_name: "{{ key_name }}"
             bastion_vm_image: "{{ bastion_vm_image }}"
             bastion_vm_flavor: "{{ bastion_vm_flavor }}"
@@ -40,7 +42,6 @@
           server: "{{ cluster_name }}-lb-0"
           floating_ip_address: "{{ openshift_public_ip }}"
       when: master_vm_group_size > 1
-
     - block:
       - name: Build the OpenShift Heat stack (minimal)
         register: heat_stack
@@ -53,6 +54,8 @@
             env_name: "{{ cluster_name }}"
             bastion_allow_cidrs: "{{ bastion_allow_cidrs }}"
             secgroup_ext_access_rules: "{{ secgroup_ext_access_rules }}"
+            openshift_network_cidr: "{{ openshift_network_cidr }}"
+            openshift_router: "{{ openshift_router }}"
             key_name: "{{ key_name }}"
             bastion_vm_image: "{{ bastion_vm_image }}"
             bastion_vm_flavor: "{{ bastion_vm_flavor }}"
@@ -69,7 +72,6 @@
           server: "{{ cluster_name }}-master-0"
           floating_ip_address: "{{ openshift_public_ip }}"
       when: master_vm_group_size == 1
-
     - name: Associate floating IP with bastion host
       os_floating_ip:
         server: "{{ cluster_name }}-bastion"
@@ -102,11 +104,38 @@
         marker: "# {mark} ANSIBLE MANAGED BLOCK {{ cluster_name }}: {{ item }}"
       with_items: "{{ groups.all }}"
 
-- name: Wait for SSH to work on all hosts
-  hosts: all
+- name: Wait for SSH to work on the bastion
+  hosts: localhost
+  connection: local
   gather_facts: no
   tasks:
-    - name: Try running setup to verify connectivity
-      setup:
-      retries: 30
-      delay: 5
+    - name: Wait for connectivity on port 22 on the bastion
+      wait_for:
+        host: "{{ bastion_public_ip }}"
+        port: 22
+        search_regex: "OpenSSH"
+        delay: 5
+        timeout: 900
+
+- name: Install nmap-ncat on bastion if need be
+  hosts: bastion
+  gather_facts: no
+  tasks:
+    - name: Install nmap-ncat
+      yum:
+        name: nmap-ncat
+        state: present
+
+- name: Wait for SSH to work on all other hosts
+  hosts: all
+  gather_facts: no
+  any_errors_fatal: yes
+  tasks:
+    - name: Wait for connectivity on port 22 on all other hosts
+      wait_for:
+        host: "{{ ansible_ssh_host }}"
+        port: 22
+        search_regex: "OpenSSH"
+        delay: 5
+        timeout: 300
+      delegate_to: "{{ hostvars[groups['bastion'][0]]['ansible_ssh_host'] }}"


### PR DESCRIPTION
It looks like new routers in cPouta take a long time to start working.
It is thus better to use an existing router instead and connect that to
the cluster network create in the Heat stack. The name of this existing
router is provided as a parameter to the stack. Also change the default
CIDR of the cluster network to a /24 from a /16, because with an
existing router one has to avoid collissions with other networks
connected to the same router.

Improve SSH connectivity checking. The setup module is not ideal for
connection checking. It is better to use wait_for. First wait for the
bastion separately, then make sure the bastion has nmap-ncat installed
and finally ensure SSH connectivity to all cluster hosts.