### PR TITLE
Feature/heat minimal

### DIFF
--- a/playbooks/openshift/files/openshift-heat-stack-minimal.yml
+++ b/playbooks/openshift/files/openshift-heat-stack-minimal.yml
@@ -1,0 +1,346 @@
+---
+heat_template_version: 2015-10-15
+
+description: >
+  Provision resources for a minimal OpenShift cluster.
+
+parameters:
+  env_name:
+    description: >
+      A name for the OpenShift environment to be used for naming resources.
+    type: string
+    default: { get_param: 'OS::stack_name' }
+  bastion_allow_ports:
+    description: >
+      Which ports to allow connections to on the bastion host.
+    type: comma_delimited_list
+    default: '22'
+  bastion_allow_cidrs:
+    description: >
+      The CIDRs of the networks where the bastion host should be accessible
+      from.
+    type: comma_delimited_list
+    default: '0.0.0.0/0'
+  secgroup_ext_access_rules:
+    description: >
+      Rules for the security group that governs external access to the system.
+    type: json
+  openshift_network_cidr:
+    description: >
+      What CIDR to use for the dedicated cluster network.
+    type: string
+    default: '192.168.0.0/16'
+  openshift_network_dns_servers:
+    description: >
+      What DNS servers to use in the dedicated cluster network.
+    type: comma_delimited_list
+    default: '193.166.4.24,193.166.4.25'
+  public_network_id:
+    description: >
+      The public network in OpenStack to which the dedicated cluster net router
+      should be connected to.
+    type: string
+    default: 'public'
+  key_name:
+    description: >
+      The name of the SSH key to initially insert into VMs.
+    type: string
+  bastion_vm_image:
+    description: >
+      What OpenStack image to use for the bastion host.
+    type: string
+  bastion_vm_flavor:
+    description: >
+      What OpenStack flavor to use for the bastion host.
+    type: string
+  bastion_cloud_config:
+    description: >
+      Configuration for cloud-init for the bastion host.
+    type: json
+  master_vm_group_size:
+    description: >
+      How many master VMs to start.
+    type: number
+  master_vm_image:
+    description: >
+      What OpenStack image to use for master hosts.
+    type: string
+  master_vm_flavor:
+    description: >
+      What OpenStack flavor to use for master VMs.
+    type: string
+  master_vm_vol_size:
+    description: >
+      The size of the Cinder volume to attach to NFS VMs.
+    type: number
+  node_ssd_vm_group_size:
+    description: >
+      How many SSD node VMs to start.
+    type: number
+  node_ssd_vm_image:
+    description: >
+      What OpenStack image to use for SSD nodes.
+    type: string
+  node_ssd_vm_flavor:
+    description: >
+      What OpenStack flavor to use for SSD node VMs.
+    type: string
+
+resources:
+
+  #-----------------------------------
+  # Security groups
+  #-----------------------------------
+
+  secgroup_bastion:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: "bastion"
+      rules:
+        repeat:
+          for_each:
+            <%port%>: { get_param: bastion_allow_ports }
+            <%cidr%>: { get_param: bastion_allow_cidrs }
+          template:
+            protocol: tcp
+            port_range_min: <%port%>
+            port_range_max: <%port%>
+            remote_ip_prefix: <%cidr%>
+
+  secgroup_common:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: "common"
+      rules:
+        - remote_mode: remote_group_id
+          remote_group_id: { get_resource: secgroup_bastion }
+        - remote_mode: remote_group_id
+          protocol: icmp
+        - remote_mode: remote_group_id
+          protocol: udp
+          port_range_min: 4789
+          port_range_max: 4789
+
+  secgroup_infra:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: infra
+      rules:
+        - remote_mode: remote_group_id
+
+  secgroup_lb:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: lb
+      rules:
+        - remote_mode: remote_group_id
+          remote_group_id: { get_resource: secgroup_common }
+
+  secgroup_ext_access:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: "ext-access"
+      rules: { get_param: secgroup_ext_access_rules }
+
+  secgroup_master:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: master
+      rules:
+       - protocol: udp
+         port_range_min: 53
+         port_range_max: 53
+         remote_mode: remote_group_id
+         remote_group_id: { get_resource: secgroup_common }
+       - protocol: tcp
+         port_range_min: 53
+         port_range_max: 53
+         remote_mode: remote_group_id
+         remote_group_id: { get_resource: secgroup_common }
+       - protocol: tcp
+         port_range_min: 8443
+         port_range_max: 8443
+         remote_mode: remote_group_id
+         remote_group_id: { get_resource: secgroup_common }
+
+  secgroup_nfs:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: nfs
+      rules:
+        - remote_mode: remote_group_id
+          remote_group_id: { get_resource: secgroup_common }
+          protocol: tcp
+          port_range_min: 2049
+          port_range_max: 2049
+
+  secgroup_node:
+    type: secgroup.yaml
+    properties:
+      env_name: { get_param: env_name }
+      name_suffix: node
+      rules:
+        - remote_mode: remote_group_id
+          remote_group_id: { get_resource: secgroup_infra }
+
+  #-----------------------------------
+  # Dedicated cluster network
+  #-----------------------------------
+
+  openshift_network:
+    type: OS::Neutron::Net
+    properties:
+       name:
+         str_replace:
+            template: env_name-name_suffix
+            params:
+              env_name: { get_param: env_name }
+              name_suffix: "network"
+
+  openshift_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: openshift_network }
+      cidr: { get_param: openshift_network_cidr }
+      dns_nameservers: { get_param: openshift_network_dns_servers }
+
+  openshift_router:
+    type: OS::Neutron::Router
+    depends_on: "openshift_subnet"
+    properties:
+      name:
+        str_replace:
+            template: env_name-name_suffix
+            params:
+              env_name: { get_param: env_name }
+              name_suffix: "router"
+      external_gateway_info:
+        network: { get_param: public_network_id }
+
+  openshift_subnet_router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: openshift_router }
+      subnet: { get_resource: openshift_subnet }
+
+  #-----------------------------------
+  # Bastion VM
+  #-----------------------------------
+
+  bastion_cloud_config_resource:
+    type: "OS::Heat::CloudConfig"
+    properties:
+      cloud_config: { get_param: bastion_cloud_config }
+
+  bastion:
+    type: OS::Nova::Server
+    depends_on: "openshift_subnet"
+    properties:
+      name:
+        str_replace:
+          template: env_name-name_suffix
+          params:
+            env_name: { get_param: env_name }
+            name_suffix: "bastion"
+      image: { get_param: bastion_vm_image }
+      networks:
+        - network: { get_resource: openshift_network }
+      flavor: { get_param: bastion_vm_flavor }
+      metadata:
+        group: "bastion"
+        stack: { get_param: env_name }
+      key_name: { get_param: key_name }
+      security_groups:
+        - { get_resource: secgroup_bastion }
+      user_data: { get_resource: bastion_cloud_config_resource }
+      user_data_format: RAW
+
+  #-----------------------------------
+  # Nova server groups (anti-affinity)
+  #-----------------------------------
+
+  master:
+    type: OS::Nova::ServerGroup
+    properties:
+      name: master
+      policies: ['anti-affinity']
+
+  node_ssd:
+    type: OS::Nova::ServerGroup
+    properties:
+      name: node_ssd
+      policies: ['anti-affinity']
+
+  #-----------------------------------
+  # VM resource groups
+  #-----------------------------------
+
+  master_vm_group:
+    type: OS::Heat::ResourceGroup
+    depends_on: "openshift_subnet"
+    properties:
+      count: { get_param: master_vm_group_size }
+      resource_def:
+        type: vm_with_volume.yaml
+        properties:
+          vm_name:
+            str_replace:
+              template: env_name-name_suffix-%index%
+              params:
+                env_name: { get_param: env_name }
+                name_suffix: "master"
+          image: { get_param: master_vm_image }
+          networks:
+            - network: { get_resource: openshift_network }
+          flavor: { get_param: master_vm_flavor }
+          metadata:
+            groups: "masters,node_masters,nfsservers"
+            stack: { get_param: env_name }
+          key_name: { get_param: key_name }
+          security_groups:
+            - { get_resource: secgroup_infra }
+            - { get_resource: secgroup_common }
+            - { get_resource: secgroup_master }
+            - { get_resource: secgroup_lb }
+            - { get_resource: secgroup_ext_access }
+          scheduler_hints:
+            group: { get_resource: master }
+          vol_name_suffix: "data"
+          vol_size: { get_param: master_vm_vol_size }
+
+  node_ssd_vm_group:
+    type: OS::Heat::ResourceGroup
+    depends_on: "openshift_subnet"
+    properties:
+      count: { get_param: node_ssd_vm_group_size }
+      resource_def:
+        type: OS::Nova::Server
+        properties:
+          name:
+            str_replace:
+              template: env_name-name_suffix-%index%
+              params:
+                env_name: { get_param: env_name }
+                name_suffix: "ssd"
+          image: { get_param: node_ssd_vm_image }
+          networks:
+            - network: { get_resource: openshift_network }
+          flavor: { get_param: node_ssd_vm_flavor }
+          metadata:
+            group: "ssd"
+            stack: { get_param: env_name }
+          key_name: { get_param: key_name }
+          security_groups:
+            - { get_resource: secgroup_node }
+            - { get_resource: secgroup_common }
+          scheduler_hints:
+            group: { get_resource: node_ssd }
+
+outputs:

--- a/playbooks/openshift/heat_deprovision.yml
+++ b/playbooks/openshift/heat_deprovision.yml
@@ -12,14 +12,15 @@
         server: "{{ cluster_name }}-lb-0"
         floating_ip_address: "{{ openshift_public_ip }}"
         state: absent
-      when: lb_vm_group_size > 0
+      when: master_vm_group_size > 1
     - name: Disassociate floating IP from first master node
       os_floating_ip:
         server: "{{ cluster_name }}-master-0"
         floating_ip_address: "{{ openshift_public_ip }}"
         state: absent
-      when: lb_vm_group_size == 0
+      when: master_vm_group_size == 1
     - name: Delete stack {{ cluster_name }}
       os_stack:
         name: "{{ cluster_name }}"
         state: absent
+        wait: yes

--- a/playbooks/openshift/heat_provision.yml
+++ b/playbooks/openshift/heat_provision.yml
@@ -2,47 +2,74 @@
 - hosts: localhost
   connection: local
   tasks:
-    - name: Build the OpenShift Heat stack
-      register: heat_stack
-      os_stack:
-        name: "{{ cluster_name }}"
-        state: present
-        template: "files/openshift-heat-stack.yml"
-        parameters:
-          env_name: "{{ cluster_name }}"
-          bastion_allow_cidrs: "{{ bastion_allow_cidrs }}"
-          secgroup_ext_access_rules: "{{ secgroup_ext_access_rules }}"
-          key_name: "{{ key_name }}"
-          bastion_vm_image: "{{ bastion_vm_image }}"
-          bastion_vm_flavor: "{{ bastion_vm_flavor }}"
-          bastion_cloud_config: "{{ bastion_cloud_config }}"
-          etcd_vm_group_size: "{{ etcd_vm_group_size }}"
-          etcd_vm_image: "{{ etcd_vm_image }}"
-          etcd_vm_flavor: "{{ etcd_vm_flavor }}"
-          lb_vm_group_size: "{{ lb_vm_group_size }}"
-          lb_vm_image: "{{ lb_vm_image }}"
-          lb_vm_flavor: "{{ lb_vm_flavor }}"
-          lb_vol_size: "{{ lb_vol_size }}"
-          nfs_vm_group_size: "{{ nfs_vm_group_size }}"
-          nfs_vm_image: "{{ nfs_vm_image }}"
-          nfs_vm_flavor: "{{ nfs_vm_flavor }}"
-          nfs_vol_size: "{{ nfs_vol_size }}"
-          master_vm_group_size: "{{ master_vm_group_size }}"
-          master_vm_image: "{{ master_vm_image }}"
-          master_vm_flavor: "{{ master_vm_flavor }}"
-          node_ssd_vm_group_size: "{{ node_ssd_vm_group_size }}"
-          node_ssd_vm_image: "{{ node_ssd_vm_image }}"
-          node_ssd_vm_flavor: "{{ node_ssd_vm_flavor }}"
-    - name: Associate floating IP with first LB node
-      os_floating_ip:
-        server: "{{ cluster_name }}-lb-0"
-        floating_ip_address: "{{ openshift_public_ip }}"
-      when: lb_vm_group_size > 0
-    - name: Associate floating IP with first master node
-      os_floating_ip:
-        server: "{{ cluster_name }}-master-0"
-        floating_ip_address: "{{ openshift_public_ip }}"
-      when: lb_vm_group_size == 0
+    - block:
+      - name: Build the OpenShift Heat stack (full)
+        register: heat_stack
+        os_stack:
+          name: "{{ cluster_name }}"
+          state: present
+          template: "files/openshift-heat-stack.yml"
+          wait: yes
+          parameters:
+            env_name: "{{ cluster_name }}"
+            bastion_allow_cidrs: "{{ bastion_allow_cidrs }}"
+            secgroup_ext_access_rules: "{{ secgroup_ext_access_rules }}"
+            key_name: "{{ key_name }}"
+            bastion_vm_image: "{{ bastion_vm_image }}"
+            bastion_vm_flavor: "{{ bastion_vm_flavor }}"
+            bastion_cloud_config: "{{ bastion_cloud_config }}"
+            etcd_vm_group_size: "{{ etcd_vm_group_size }}"
+            etcd_vm_image: "{{ etcd_vm_image }}"
+            etcd_vm_flavor: "{{ etcd_vm_flavor }}"
+            lb_vm_group_size: "{{ lb_vm_group_size }}"
+            lb_vm_image: "{{ lb_vm_image }}"
+            lb_vm_flavor: "{{ lb_vm_flavor }}"
+            lb_vol_size: "{{ lb_vol_size }}"
+            nfs_vm_group_size: "{{ nfs_vm_group_size }}"
+            nfs_vm_image: "{{ nfs_vm_image }}"
+            nfs_vm_flavor: "{{ nfs_vm_flavor }}"
+            nfs_vol_size: "{{ nfs_vol_size }}"
+            master_vm_group_size: "{{ master_vm_group_size }}"
+            master_vm_image: "{{ master_vm_image }}"
+            master_vm_flavor: "{{ master_vm_flavor }}"
+            node_ssd_vm_group_size: "{{ node_ssd_vm_group_size }}"
+            node_ssd_vm_image: "{{ node_ssd_vm_image }}"
+            node_ssd_vm_flavor: "{{ node_ssd_vm_flavor }}"
+      - name: Associate floating IP with first LB node
+        os_floating_ip:
+          server: "{{ cluster_name }}-lb-0"
+          floating_ip_address: "{{ openshift_public_ip }}"
+      when: master_vm_group_size > 1
+
+    - block:
+      - name: Build the OpenShift Heat stack (minimal)
+        register: heat_stack
+        os_stack:
+          name: "{{ cluster_name }}"
+          state: present
+          template: "files/openshift-heat-stack-minimal.yml"
+          wait: yes
+          parameters:
+            env_name: "{{ cluster_name }}"
+            bastion_allow_cidrs: "{{ bastion_allow_cidrs }}"
+            secgroup_ext_access_rules: "{{ secgroup_ext_access_rules }}"
+            key_name: "{{ key_name }}"
+            bastion_vm_image: "{{ bastion_vm_image }}"
+            bastion_vm_flavor: "{{ bastion_vm_flavor }}"
+            bastion_cloud_config: "{{ bastion_cloud_config }}"
+            master_vm_group_size: "{{ master_vm_group_size }}"
+            master_vm_image: "{{ master_vm_image }}"
+            master_vm_flavor: "{{ master_vm_flavor }}"
+            master_vm_vol_size: "{{ master_vm_vol_size }}"
+            node_ssd_vm_group_size: "{{ node_ssd_vm_group_size }}"
+            node_ssd_vm_image: "{{ node_ssd_vm_image }}"
+            node_ssd_vm_flavor: "{{ node_ssd_vm_flavor }}"
+      - name: Associate floating IP with master
+        os_floating_ip:
+          server: "{{ cluster_name }}-master-0"
+          floating_ip_address: "{{ openshift_public_ip }}"
+      when: master_vm_group_size == 1
+
     - name: Associate floating IP with bastion host
       os_floating_ip:
         server: "{{ cluster_name }}-bastion"

--- a/playbooks/openshift/install.yml
+++ b/playbooks/openshift/install.yml
@@ -1,2 +1,2 @@
 ---
-- include: "{{ os_ansible_path }}/playbooks/byo/config.yml"
+- include: "{{ os_ansible_path|default('../../../openshift-ansible') }}/playbooks/byo/config.yml"

--- a/roles/lvm_storage/tasks/configure_volume.yml
+++ b/roles/lvm_storage/tasks/configure_volume.yml
@@ -6,6 +6,7 @@
   command: vgdisplay {{ vg_name }}
   register: test_vg
   ignore_errors: yes
+  failed_when: false
   changed_when: false
 
 # in case the volumes were there, activate them in case they are reused from a previous incarnation


### PR DESCRIPTION
minimal/single master provisioning:
- added a separate heat template for single master/minimal deployment
- rearranged multimaster/single master provisioning code to blocks

minor enhancements:
- pick openshift-ansible from sibling directory by default
- suppress false errors for lv scans