### PR TITLE
Use profile_tasks callback

### DIFF
--- a/playbooks/openshift/ansible.cfg
+++ b/playbooks/openshift/ansible.cfg
@@ -4,3 +4,4 @@ pipelining = True
 
 [defaults]
 ansible_python_interpreter = "/usr/bin/env python"
+callback_whitelist = timer,mail,profile_tasks


### PR DESCRIPTION
Configure callback_whitelist in ansible.cfg so that it includes the
profile_tasks callback function that gives additional timing information
during playbook runs.