### PR TITLE
Configuration for Cinder storage class

### DIFF
--- a/playbooks/openshift/post_install.yml
+++ b/playbooks/openshift/post_install.yml
@@ -1,10 +1,10 @@
 - name: Run NFS volume creation
   include: ../../../openshift-ansible-tourunen/setup_lvm_nfs.yml
 
-- name: Import objects through master-1
+- name: Import objects through first master
   hosts: masters[0]
   tasks:
-    - name: copy nfs_pv definitions to master-1
+    - name: copy nfs_pv definitions to first master
       copy:
         src: /tmp/nfs_pv
         dest: /home/cloud-user/
@@ -23,7 +23,7 @@
       shell: oc volume dc/docker-registry --add --mount-path=/registry --overwrite --name=registry-storage -t pvc --claim-size=200Gi --claim-name=registry
       when: existing_registry_pv.stdout_lines | length == 0
 
-    - name: copy default project template to master-1
+    - name: copy default project template to first master
       template:
         src: "{{ oso_default_project_request|default('templates/project-request.yaml') }}"
         dest: /home/cloud-user/project-request.yaml
@@ -41,3 +41,24 @@
     - name: update project template
       shell: oc replace -f /home/cloud-user/project-request.yaml
       when: existing_template.stdout_lines | length > 0
+
+    - name: copy StorageClass object template for Cinder storage
+      template:
+        src: "templates/cinder-storageclass.yaml.j2"
+        dest: /home/cloud-user/cinder-storageclass.yaml
+      register: storageclass_template
+
+    - name: check if StorageClass exists
+      shell: "oc get storageclass -n default {{ storage_class_name }}"
+      register: existing_storageclass
+      changed_when: false
+      failed_when: false
+
+    - name: create StorageClass object
+      shell: oc create -f /home/cloud-user/cinder-storageclass.yaml
+      when: existing_storageclass.stdout_lines | length == 0
+
+    - name: update StorageClass object
+      shell: oc replace -f /home/cloud-user/cinder-storageclass.yaml
+      when: existing_storageclass.stdout_lines | length > 0
+      changed_when: storageclass_template.changed

--- a/playbooks/openshift/templates/cinder-storageclass.yaml.j2
+++ b/playbooks/openshift/templates/cinder-storageclass.yaml.j2
@@ -1,0 +1,13 @@
+---
+kind: "StorageClass"
+apiVersion: "storage.k8s.io/v1beta1"
+metadata:
+  name: "{{ storage_class_name }}"
+  annotations:
+{% for annotation in storage_class_annotations %}
+    {{ annotation.name }}: "{{ annotation.value }}"
+{% endfor %}
+provisioner: "kubernetes.io/cinder"
+parameters:
+  type: "{{ storage_class_cinder_type }}"
+  availability: "nova"

--- a/playbooks/openshift/templates/project-request.yaml
+++ b/playbooks/openshift/templates/project-request.yaml
@@ -85,6 +85,14 @@ objects:
     scopes:
     - NotTerminating
 
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: storage-resources
+  spec:
+    hard:
+      requests.storage: "{{ storage_default_quota|default('50Gi') }}"
+
 # Limit range
 - apiVersion: "v1"
   kind: "LimitRange"


### PR DESCRIPTION
Add post-install tasks and a Jinja2 template for adding a Cinder storage
class in OpenShift.

Make it possible to configure a default storage quota for new projects
in OpenShift using a ResourceQuota object. The quota is based on a
variable and a default is provided for overriding the value. Set a
default of 500Gi to start with.