### PR TITLE
registry now uses cinder persistent storage

### DIFF
--- a/playbooks/openshift/heat_deprovision.yml
+++ b/playbooks/openshift/heat_deprovision.yml
@@ -1,4 +1,36 @@
 ---
+
+- name: Remove projects and persistent volumes still in use
+  gather_facts: no
+  hosts: masters[0]
+  tasks:
+    - name: Check if SSH works
+      shell: ssh -o ConnectTimeout=10 -F /tmp/pac.ssh.config cloud-user@{{ cluster_name }}-master-0 'echo success'
+      register: ssh_result
+      failed_when: false
+      delegate_to: localhost
+    - name: remove registry and its PVC
+      shell: "{{ item }}"
+      with_items:
+      - oc delete dc docker-registry -n default
+      - oc delete pvc registry -n default
+      failed_when: false
+      when: ssh_result.stdout.find('success') == 0
+    - name: remove projects, this will release the PVCs too
+      shell: "{{ item }}"
+      with_items:
+      - oc delete projects --all
+      failed_when: false
+      when: ssh_result.stdout.find('success') == 0
+    - name: wait for recycler pod to remove the dynamically provisioned PVs
+      shell: oc get pv -o jsonpath='{.items[*].spec.cinder}'
+      register: result
+      until: result.stdout_lines|length == 0
+      retries: 60
+      delay: 5
+      failed_when: false
+      when: ssh_result.stdout.find('success') == 0
+
 - hosts: localhost
   gather_facts: no
   connection: local

--- a/playbooks/openshift/heat_provision.yml
+++ b/playbooks/openshift/heat_provision.yml
@@ -21,7 +21,7 @@
             key_name: "{{ key_name }}"
             bastion_vm_image: "{{ bastion_vm_image }}"
             bastion_vm_flavor: "{{ bastion_vm_flavor }}"
-            bastion_cloud_config: "{{ bastion_cloud_config }}"
+            bastion_cloud_config: "{{ bastion_cloud_config|default({}) }}"
             etcd_vm_group_size: "{{ etcd_vm_group_size }}"
             etcd_vm_image: "{{ etcd_vm_image }}"
             etcd_vm_flavor: "{{ etcd_vm_flavor }}"
@@ -61,7 +61,7 @@
             key_name: "{{ key_name }}"
             bastion_vm_image: "{{ bastion_vm_image }}"
             bastion_vm_flavor: "{{ bastion_vm_flavor }}"
-            bastion_cloud_config: "{{ bastion_cloud_config }}"
+            bastion_cloud_config: "{{ bastion_cloud_config|default({}) }}"
             master_vm_group_size: "{{ master_vm_group_size }}"
             master_vm_image: "{{ master_vm_image }}"
             master_vm_flavor: "{{ master_vm_flavor }}"
@@ -92,6 +92,16 @@
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
         marker: "# {mark} ANSIBLE MANAGED BLOCK for global PAC options"
+    - name: add ssh config entry for bastion
+      blockinfile:
+        create: yes
+        mode: '0600'
+        dest: "/tmp/pac.ssh.config"
+        block: |
+          Host {{ item }} {{ hostvars[item].ansible_ssh_host }}
+              HostName {{ bastion_public_ip }}
+        marker: "# {mark} ANSIBLE MANAGED BLOCK {{ cluster_name }}: {{ item }}"
+      with_items: "{{ groups.bastion }}"
     - name: add ssh config entries for hosts
       blockinfile:
         create: yes
@@ -100,11 +110,11 @@
         block: |
           Host {{ item }} {{ hostvars[item].ansible_ssh_host }}
               HostName {{ hostvars[item].ansible_ssh_host }}
-              StrictHostKeyChecking no
-              UserKnownHostsFile /dev/null
               ProxyCommand ssh -F /tmp/pac.ssh.config -q cloud-user@{{ bastion_public_ip }} nc %h %p
         marker: "# {mark} ANSIBLE MANAGED BLOCK {{ cluster_name }}: {{ item }}"
-      when: item != "localhost"
+      when:
+      - item != "localhost"
+      - item != "{{ cluster_name }}-bastion"
       with_items: "{{ groups.all }}"
     - name: Wait for connectivity on port 22 on the bastion
       wait_for:
@@ -113,10 +123,18 @@
         search_regex: "OpenSSH"
         delay: 5
         timeout: 900
+    - name: Wait for SSH to work
+      shell: ssh -F /tmp/pac.ssh.config cloud-user@{{ bastion_public_ip }} 'echo success'
+      register: result
+      until: result.stdout.find('success') != -1
+      retries: 30
+      delay: 5
+      changed_when: false
 
 - name: Install nmap-ncat on bastion if need be
   hosts: bastion
   gather_facts: no
+  become: yes
   tasks:
     - name: Install nmap-ncat
       yum:

--- a/playbooks/openshift/post_install.yml
+++ b/playbooks/openshift/post_install.yml
@@ -1,5 +1,6 @@
 - name: Run NFS volume creation
   include: ../../../openshift-ansible-tourunen/setup_lvm_nfs.yml
+  when: provision_nfs_pvs|default(false)|bool
 
 - name: Import objects through first master
   hosts: masters[0]
@@ -8,20 +9,12 @@
       copy:
         src: /tmp/nfs_pv
         dest: /home/cloud-user/
+      when: provision_nfs_pvs|default(false)|bool
 
     - name: create PVs
       shell: for vol in nfs_pv/persistent-volume.pvol*; do oc create -f $vol; done
       failed_when: false
-
-    - name: check if registry PV exists
-      shell: oc get pvc -n default registry
-      register: existing_registry_pv
-      changed_when: false
-      failed_when: false
-
-    - name: add a persistent volume to the registry
-      shell: oc volume dc/docker-registry --add --mount-path=/registry --overwrite --name=registry-storage -t pvc --claim-size=200Gi --claim-name=registry
-      when: existing_registry_pv.stdout_lines | length == 0
+      when: provision_nfs_pvs|default(false)|bool
 
     - name: copy default project template to first master
       template:
@@ -62,3 +55,13 @@
       shell: oc replace -f /home/cloud-user/cinder-storageclass.yaml
       when: existing_storageclass.stdout_lines | length > 0
       changed_when: storageclass_template.changed
+
+    - name: check if registry PVC exists
+      shell: oc get pvc -n default registry
+      register: existing_registry_pv
+      changed_when: false
+      failed_when: false
+
+    - name: add a persistent volume to the registry
+      shell: oc volume dc/docker-registry --add --mount-path=/registry --overwrite --name=registry-storage -t pvc --claim-size=200Gi --claim-name=registry
+      when: existing_registry_pv.stdout_lines | length == 0


### PR DESCRIPTION
Moving registry PVC allocation after Cinder dynamic storage has been
initialized, making registry use Cinder instead of NFS. This will remove
the hard requirement of having NFS PVs configured for a simple
deployment.