### PR TITLE
Set gather_facts: no for many localhost plays

### DIFF
--- a/playbooks/openshift/heat_deprovision.yml
+++ b/playbooks/openshift/heat_deprovision.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  gather_facts: no
   connection: local
   tasks:
     - name: Disassociate floating IP from bastion

--- a/playbooks/openshift/heat_provision.yml
+++ b/playbooks/openshift/heat_provision.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  gather_facts: no
   connection: local
   tasks:
     - block:
@@ -102,6 +103,7 @@
               UserKnownHostsFile /dev/null
               ProxyCommand ssh -F /tmp/pac.ssh.config -q cloud-user@{{ bastion_public_ip }} nc %h %p
         marker: "# {mark} ANSIBLE MANAGED BLOCK {{ cluster_name }}: {{ item }}"
+      when: item != "localhost"
       with_items: "{{ groups.all }}"
 
 - name: Wait for SSH to work on the bastion

--- a/playbooks/openshift/pre_install.yml
+++ b/playbooks/openshift/pre_install.yml
@@ -54,6 +54,8 @@
 
 - name: Create temporary files on a RAM disk for TLS certs and keys
   hosts: localhost
+  gather_facts: no
+  connection: local
   tasks:
     - name: Create a temporary directory on the RAM disk
       file:


### PR DESCRIPTION
We don't really need to gather facts for e.g. OpenStack API calls, so
let's not do it. It can cause unnecessary issues.

Also, make sure to use connection: local whenever running plays on the
localhost.