### PR TITLE
Get context for current environment when needed

### DIFF
--- a/playbooks/openshift/environment_context.yml
+++ b/playbooks/openshift/environment_context.yml
@@ -1,0 +1,6 @@
+- name: Set facts for environment context
+  set_fact:
+    os_env_path: "{{ os_env_path|default('../../../openshift-environments') }}"
+- name: Get context for current environment
+  include_vars:
+    dir: "{{ os_env_path }}/group_vars/{{ cluster_name }}"

--- a/playbooks/openshift/heat_deprovision.yml
+++ b/playbooks/openshift/heat_deprovision.yml
@@ -3,6 +3,7 @@
   gather_facts: no
   connection: local
   tasks:
+    - include: environment_context.yml
     - name: Disassociate floating IP from bastion
       os_floating_ip:
         server: "{{ cluster_name }}-bastion"

--- a/playbooks/openshift/heat_provision.yml
+++ b/playbooks/openshift/heat_provision.yml
@@ -3,6 +3,7 @@
   gather_facts: no
   connection: local
   tasks:
+    - include: environment_context.yml
     - block:
       - name: Build the OpenShift Heat stack (full)
         register: heat_stack
@@ -105,12 +106,6 @@
         marker: "# {mark} ANSIBLE MANAGED BLOCK {{ cluster_name }}: {{ item }}"
       when: item != "localhost"
       with_items: "{{ groups.all }}"
-
-- name: Wait for SSH to work on the bastion
-  hosts: localhost
-  connection: local
-  gather_facts: no
-  tasks:
     - name: Wait for connectivity on port 22 on the bastion
       wait_for:
         host: "{{ bastion_public_ip }}"

--- a/playbooks/openshift/pre_install.yml
+++ b/playbooks/openshift/pre_install.yml
@@ -57,6 +57,7 @@
   gather_facts: no
   connection: local
   tasks:
+    - include: environment_context.yml
     - name: Create a temporary directory on the RAM disk
       file:
         path: "/dev/shm/{{ cluster_name }}"


### PR DESCRIPTION
When running tasks such as OpenStack API calls on the localhost, the
right context may not have been available previously. Add a
localhost_context.yml file with two tasks for getting context from the
correct group under group_vars. Include this file for those plays that
need it.