### PR TITLE
allow empty server groups with OpenStack Newton

### DIFF
--- a/tasks/vm_group_provision.yml
+++ b/tasks/vm_group_provision.yml
@@ -13,7 +13,9 @@
   register: server_group_res
   when: server_group_name is defined and server_group_name is not none
 
-- set_fact: server_group_id={{ server_group_res.id }}
+- set_fact:
+    scheduler_hints:
+      group: "{{ server_group_res.id }}"
   when: server_group_name is defined and server_group_name is not none
 
 - name: provision volumes for {{ vm_group_name }}
@@ -34,8 +36,7 @@
     boot_from_volume: "{{ vm_group.boot_from_volume | default(False) }}"
     terminate_volume: yes
     volume_size: 50
-    scheduler_hints:
-      group: "{{ server_group_id | default(none) }}"
+    scheduler_hints: "{{ scheduler_hints | default({}) }}"
     wait: no
   with_sequence: count={{ vm_group.num_vms|default(1) }}
   async: 300


### PR DESCRIPTION
This patch changes scheduler hint assignment mechanism so that
if no server group is assigned, scheduler hints is an empty
dictionary. Previously the group -key was just set to '', but
this does not work anymore.

Fixes #87 