### PR TITLE
configure lvm and docker on etcd servers

### DIFF
--- a/playbooks/openshift/pre_install.yml
+++ b/playbooks/openshift/pre_install.yml
@@ -22,6 +22,7 @@
     - masters
     - nodes
     - lbs
+    - etcd
   become: yes
   roles:
     - role: lvm_storage


### PR DESCRIPTION
Prior to this LVM was not configured on etcd hosts and docker storage
was left on defaults. Docker was installed by openshift, unlike
the rest of the hosts.