### PR TITLE
update Centos-7 image reference to new cPouta convention

### DIFF
--- a/CREATE_BASTION_HOST.md
+++ b/CREATE_BASTION_HOST.md
@@ -26,7 +26,7 @@ Boot a new VM from the latest CentOS 7 image that is provided by CSC
   - pick a name for the VM, for example 'bastion'
   - Flavor: standard.tiny
   - Instance boot source: Image
-  - Image Name: Latest public Centos image (CentOS-7.0 at the time of writing)
+  - Image Name: Latest public Centos image (CentOS-7 at the time of writing)
   - Keypair: select your key
   - Security Groups: select *default* and *bastion*
   - Network: select the desired network (you probably only have one, which is the default)

--- a/tasks/vm_group_provision.yml
+++ b/tasks/vm_group_provision.yml
@@ -28,7 +28,7 @@
   os_server:
     name: "{{ cluster_name }}-{{ vm_group_name }}-{{ item }}"
     flavor: "{{ vm_group.flavor }}"
-    image: "{{ vm_group.image|default('CentOS-7.0') }}"
+    image: "{{ vm_group.image|default('CentOS-7') }}"
     key_name: "{{ ssh_key }}"
     network: "{{ network_name }}"
     security_groups: "{{ security_groups }}"


### PR DESCRIPTION
CentOS 7 image is now (correctly) called CentOS-7 in cPouta. Update the defaults to match this.